### PR TITLE
Show higher quality image.

### DIFF
--- a/src/js/content-script.js
+++ b/src/js/content-script.js
@@ -6,7 +6,7 @@ function makeSetAudioURL(videoElement, url) {
       vid = vid.substring(0, pos);
     }
 
-    var bgUrl = `https://img.youtube.com/vi/${vid}/0.jpg`;
+    var bgUrl = `https://img.youtube.com/vi/${vid}/maxresdefault.jpg`;
     videoElement.style.background = `transparent url(${bgUrl}) no-repeat center`;
     videoElement.style.backgroundSize = '80%';
   }


### PR DESCRIPTION
The thumbnail always loads in a quality of 480p. This fix loads the best thumbnail available.