### PR TITLE
Adding support for YouTube Music

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,6 +16,7 @@
   "permissions": [
     "tabs", "webRequest", "storage",
     "*://www.youtube.com/*",
+    "*://music.youtube.com/*",
     "*://*.googlevideo.com/*"
   ],
   "browser_action": {
@@ -24,6 +25,13 @@
   "content_scripts": [
     {
       "matches": ["*://www.youtube.com/*"],
+      "js": ["js/content-script.js"],
+      "css": ["css/content-script.css"],
+      "run_at": "document_start",
+      "all_frames": true
+    },
+    {
+      "matches": ["*://music.youtube.com/*"],
       "js": ["js/content-script.js"],
       "css": ["css/content-script.css"],
       "run_at": "document_start",


### PR DESCRIPTION
Added the permission and content script matching to "*://music.youtube.com/*" in order to allow the extension to work with YouTube Music as well.
I performed a quick test and it was working as intended.

<img width="960" alt="YouTube_Music_AudioOnly" src="https://user-images.githubusercontent.com/39421368/85182477-10c79380-b289-11ea-8f84-2a18876bb498.png">

