### PR TITLE
Remove additional parameter from the request and fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note: It doesn't support Youtube live videos.
 
 1. After cloning the repo,  run `yarn run start`.
 2. Open chrome, go to extensions tab, load unpacked extension and select
-   `dev/build` directory.
+   `build/dev` directory.
 3. Go to Youtube and see extension in live.
 
 In case you edit code, it would automatically rebuild the extension and after

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -72,7 +72,7 @@ class Background {
       return;
     }
 
-    const parametersToBeRemoved = ['range', 'rn', 'rbuf'];
+    const parametersToBeRemoved = ['range', 'rn', 'rbuf', 'ump'];
     const audioURL = this.removeURLParameters(url, parametersToBeRemoved);
     if (audioURL && this.tabIds.get(tabId) !== audioURL) {
       this.tabIds.set(tabId, audioURL);


### PR DESCRIPTION
An additional parameter must be removed from the request to make the extension play the audio.