### PR TITLE
remove "and refresh" instructions from video overlay

### DIFF
--- a/src/js/content-script.ts
+++ b/src/js/content-script.ts
@@ -67,7 +67,7 @@ function showAudioOnlyInformation(videoElement: HTMLVideoElement) {
     alertText.className = 'alert_text';
     alertText.innerHTML =
       'Audio Only. To watch video, ' +
-      'click on the extension icon above and refresh your page.';
+      'click on the extension icon above.';
 
     extensionAlert.appendChild(alertText);
     const videoParent = videoElement.parentNode;


### PR DESCRIPTION
The button refreshes, so I say you shouldn't tell people to refresh